### PR TITLE
Missing config

### DIFF
--- a/javascript/spliffy/config.yaml
+++ b/javascript/spliffy/config.yaml
@@ -1,0 +1,3 @@
+framework:
+  github: srfnstack/spliffy
+  version: 0.7


### PR DESCRIPTION
Hi @snowbldr,

This `PR` adds missing `config.yaml` to https://github.com/the-benchmarker/web-frameworks/pull/4795

Regards,